### PR TITLE
fix: guard against division by zero in rating formulas

### DIFF
--- a/src/utils/rating.ts
+++ b/src/utils/rating.ts
@@ -254,6 +254,7 @@ const getAverageArtifactScoreForScene = (
         : [avgPerformerScore];
 
     const allScores = [studioScore, ...tagScores, ...performerScores];
+    if (allScores.length === 0) return 0;
     const averageScore = Math.floor(
         allScores.reduce((acc, score) => acc + score, 0) / allScores.length
     );
@@ -291,9 +292,9 @@ const getSceneRating = (
         };
     }
 
-    const oCountMultiplier = Number(
-        (oCounter / avgLikesPerLikedScene / 20 + 1).toFixed(4)
-    );
+    const oCountMultiplier = avgLikesPerLikedScene === 0
+        ? 1
+        : Number((oCounter / avgLikesPerLikedScene / 20 + 1).toFixed(4));
 
     let rating100 = Math.floor(averageArtifactScore * oCountMultiplier);
     if (rating100 > 100) {


### PR DESCRIPTION
## Summary
- Guard against NaN/Infinity in rating calculations when no scenes have been liked
- `avgLikesPerLikedScene === 0` now defaults multiplier to 1 instead of dividing by zero
- Empty score arrays return 0 early instead of dividing by length

Closes #1