### PR TITLE
fix: prevent array mutation from in-place sort operations

### DIFF
--- a/src/controllers/analyzeStudios.ts
+++ b/src/controllers/analyzeStudios.ts
@@ -68,7 +68,7 @@ export const analyzeStudiosController = async () => {
     }
     logger.success("Hydration completed.");
 
-    const sortedByTotalDesc = hydratedResults.sort((a, b) => {
+    const sortedByTotalDesc = [...hydratedResults].sort((a, b) => {
         return b.o_counter - a.o_counter;
     });
     const favoritesByTotal = sortedByTotalDesc.slice(0, 100);
@@ -76,7 +76,7 @@ export const analyzeStudiosController = async () => {
     logger.success('Your Top 100 Studios by "Total Os" are:');
     logger.table(favoritesByTotalTable);
 
-    const sortedByPercentDesc = hydratedResults.sort((a, b) => {
+    const sortedByPercentDesc = [...hydratedResults].sort((a, b) => {
         return b.o_percent - a.o_percent;
     });
     const favoritesByPercent = sortedByPercentDesc.slice(0, 100);

--- a/src/controllers/organizeLibrary.ts
+++ b/src/controllers/organizeLibrary.ts
@@ -332,7 +332,7 @@ const generatePerformerFolders = (
             : matchingPerformers;
 
     // Sort by o_counter descending (highest first)
-    const sortedPerformers = filteredPerformers.sort(
+    const sortedPerformers = [...filteredPerformers].sort(
         (a, b) => (b.o_counter ?? 0) - (a.o_counter ?? 0)
     );
     const topPerformer = sortedPerformers[0];

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -20,7 +20,7 @@ export const sortArrayOfObjects = (
 
     const { direction, secondarySortBy } = _options;
 
-    return arr.sort((a, b) => {
+    return [...arr].sort((a, b) => {
         if (direction === "ASC") {
             return (
                 a[sortBy] - b[sortBy] || a[secondarySortBy] - b[secondarySortBy]

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -22,7 +22,7 @@ export const copyScene = async (
 
     const sceneTitle = scene.title || videoFile.name;
 
-    const performersSorted = scene.performers.sort((a, b) => {
+    const performersSorted = [...scene.performers].sort((a, b) => {
         const aGender = a.gender || "ZZZZZZZZZZZZZZZZZZsortlast";
         const bGender = b.gender || "ZZZZZZZZZZZZZZZZZZsortlast";
         const aOCounter = a.o_counter ?? 0;

--- a/src/utils/scenes.ts
+++ b/src/utils/scenes.ts
@@ -312,7 +312,7 @@ const scoreScenes = (
 };
 
 const sortScenesByCustomScore = (scenes: Scene[]): Scene[] => {
-    return scenes.sort((a: any, b: any) => {
+    return [...scenes].sort((a: any, b: any) => {
         return (
             (b.phoenixCustomScoring?.score ?? 0) -
             (a.phoenixCustomScoring?.score ?? 0)


### PR DESCRIPTION
## Summary
- Replace `.sort()` with `[...arr].sort()` across 5 files to prevent in-place mutation
- Fixes studio analysis where "Top 100 by Total" was silently re-sorted by the subsequent "Top 100 by Percent" sort
- Prevents scene and performer arrays from being mutated as side effects

Closes #2