### PR TITLE
refactor: consolidate secrets to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+STASH_URL=http://localhost:9999
+STASH_API_KEY=your-api-key-here
+
+# Path prefix inside Stash's Docker container (default: /data)
+# Used to translate Stash file paths to local filesystem paths
+STASH_DATA_PATH=/data

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,30 +5,33 @@ import { input, print } from "./utils/terminal.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const CONFIG_PATH = path.resolve(__dirname, "../config/secrets.json");
+const ENV_PATH = path.resolve(__dirname, "../.env");
 
 export type StashConfig = {
     url: string;
     apiKey: string;
 };
 
-export function ensureConfigFile(): StashConfig | null {
-    if (!fs.existsSync(CONFIG_PATH)) {
-        // Prompt user for URL and API Key
-        // For now, create an empty config file
-        fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
-        fs.writeFileSync(
-            CONFIG_PATH,
-            JSON.stringify({ url: "", apiKey: "" }, null, 2)
-        );
-        return null;
+export function loadConfig(): StashConfig | null {
+    const url = process.env.STASH_URL;
+    const apiKey = process.env.STASH_API_KEY;
+
+    if (url && apiKey) {
+        return { url, apiKey };
     }
-    const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
-    return JSON.parse(raw);
+    return null;
 }
 
-export function saveConfig(config: StashConfig) {
-    fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+export function saveConfigToEnv(config: StashConfig) {
+    const lines = [
+        `STASH_URL=${config.url}`,
+        `STASH_API_KEY=${config.apiKey}`,
+        "",
+        "# Path prefix inside Stash's Docker container (default: /data)",
+        "STASH_DATA_PATH=/data",
+        "",
+    ];
+    fs.writeFileSync(ENV_PATH, lines.join("\n"));
 }
 
 export async function promptForConfig(): Promise<StashConfig> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,19 @@ import "dotenv/config";
 import { StashApp } from "stashapp-api";
 import { buildMenu } from "./commands/menus/buildMenu.js";
 import { getMainMenuItems } from "./commands/menus/menuItems.js";
-import { ensureConfigFile, promptForConfig, saveConfig } from "./config.js";
+import { loadConfig, promptForConfig, saveConfigToEnv } from "./config.js";
 import { setStashInstance } from "./stash.js";
 
 export const start = async () => {
-    let config = ensureConfigFile();
-    if (!config || !config.url || !config.apiKey) {
+    let config = loadConfig();
+    if (!config) {
         config = await promptForConfig();
-        saveConfig(config);
-        console.log("Config saved. Please restart the app.");
-        process.exit(0);
+        saveConfigToEnv(config);
+        // Re-set env vars so the rest of the app can use them
+        process.env.STASH_URL = config.url;
+        process.env.STASH_API_KEY = config.apiKey;
     }
-    // Establish connection to StashApp
+
     const stash = StashApp.init({ url: config.url, apiKey: config.apiKey });
     setStashInstance(stash);
 

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -72,7 +72,7 @@ export const copyScene = async (
     }
 
     if (scene.paths?.screenshot) {
-        const posterURL = `${scene.paths.screenshot}&apikey=${process.env.GRAPHQL_API_KEY}`;
+        const posterURL = `${scene.paths.screenshot}&apikey=${process.env.STASH_API_KEY}`;
         const posterDestPath = path.join(
             finalDestinationFolder,
             `${newFileNameNoExt}-poster.jpg`
@@ -123,7 +123,7 @@ export const generateActorsMetadata = async (
 
             await ensureDirectoriesExist(finalDestinationFolder);
 
-            const imageURL = `${performer.image_path}&apikey=${process.env.GRAPHQL_API_KEY}`;
+            const imageURL = `${performer.image_path}&apikey=${process.env.STASH_API_KEY}`;
             const destFilePath = path.join(
                 finalDestinationFolder,
                 "folder.jpg"


### PR DESCRIPTION
## Summary
- Replace `config/secrets.json` with `.env` as the single source of truth for credentials
- Unify `GRAPHQL_API_KEY` and config file API key into one `STASH_API_KEY` env var
- Add `.env.example` template
- Interactive prompt fallback still works on first run, writes `.env` directly