### PR TITLE
refactor: migrate to stashapp-api v1 (GenQL)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# stashapp-cli
+
+Interactive CLI for Stash library analytics and file management. Menu-driven TypeScript app built on `stashapp-api`.
+
+## Build & Run
+
+```bash
+npm run build          # tsc compile
+npm run start          # node dist/index.js
+npm run dev            # build + start
+```
+
+Config lives in `config/secrets.json` (Stash URL + API key). Created on first run via interactive prompts.
+
+## Architecture
+
+- **Entry**: `src/index.ts` → loads config, inits `StashApp`, builds menu
+- **Singleton**: `src/stash.ts` → `getStashInstance()` used by all controllers
+- **Menu system**: `src/commands/menus/` → `buildMenu()` with nested Inquirer prompts
+- **Controllers**: `src/controllers/` → each feature is a controller function
+- **Utils**: `src/utils/` → shared helpers (rating formulas, formatting, filesystem, NFO generation)
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `src/controllers/rateStashController.ts` | Auto-rating engine (1-100 scale) with mutation support |
+| `src/controllers/analyzePerformers.ts` | Performer engagement stats by gender |
+| `src/controllers/analyzeStudios.ts` | Studio ranking by engagement + cleanup candidates |
+| `src/controllers/copyFiles.ts` | Copy scenes to destination with smart space-fill |
+| `src/controllers/organizeLibrary.ts` | Rename/reorganize files by studio/performer/template |
+| `src/controllers/cleanEmptyFolders.ts` | Recursive empty folder cleanup |
+| `src/utils/rating.ts` | Rating formulas for performers/studios/tags/scenes |
+| `src/utils/nfo.ts` | Emby/Jellyfin NFO XML generation |
+| `src/utils/scenes.ts` | Scene filtering, deduplication, scoring |
+
+## Dependencies
+
+- `stashapp-api` — typed GraphQL client for Stash
+- `@inquirer/prompts` — interactive CLI prompts
+- `chalk` — colored terminal output
+- `terminal-kit` — progress bars, advanced terminal rendering
+- `fast-xml-parser` — NFO XML generation
+
+## Conventions
+
+- All stashapp-api calls go through `getStashInstance()` singleton
+- `per_page: -1` fetches all results (no pagination)
+- Rating scale is 0-100 (`rating100` field)
+- O-counter (orgasm tracking) is the primary engagement metric
+- Controllers handle both UI interaction and business logic

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "filesize": "^10.1.6",
                 "graphql-tag": "^2.12.6",
                 "humanize-duration": "^3.32.1",
-                "stashapp-api": "^0.2.2",
+                "stashapp-api": "^1.0.0",
                 "terminal-kit": "^3.1.2"
             },
             "devDependencies": {
@@ -262,13 +262,25 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
-        "node_modules/@graphql-typed-document-node/core": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
-            "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
-            "license": "MIT",
+        "node_modules/@genql/runtime": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/@genql/runtime/-/runtime-2.10.0.tgz",
+            "integrity": "sha512-hWy4fkHAk0OUW/cmjAOhbE3PnR9YfwaE8DRl5oEf7r9K6Owju8ogTDV3RMkG6Vm57H9xYxI5+am5ImAUbqPH8A==",
+            "license": "ISC",
+            "dependencies": {
+                "@types/qs": "^6.9.0",
+                "@types/ws": "^6.0.1",
+                "graphql-query-batcher": "^1.0.1",
+                "isomorphic-unfetch": "^3.0.0",
+                "lodash": "^4.17.20",
+                "subscriptions-transport-ws": "^0.9.16",
+                "tslib": "^2.0.0",
+                "utility-types": "^3.10.0",
+                "ws": "^6.1.4",
+                "zen-observable-ts": "^0.8.21"
+            },
             "peerDependencies": {
-                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+                "graphql": "*"
             }
         },
         "node_modules/@humanfs/core": {
@@ -802,11 +814,16 @@
             "version": "24.3.0",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
             "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
-            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.10.0"
             }
+        },
+        "node_modules/@types/qs": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+            "license": "MIT"
         },
         "node_modules/@types/terminal-kit": {
             "version": "2.5.7",
@@ -816,6 +833,15 @@
             "license": "MIT",
             "dependencies": {
                 "@types/nextgen-events": "*"
+            }
+        },
+        "node_modules/@types/ws": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
+            "integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1291,6 +1317,12 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/async-limiter": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+            "license": "MIT"
+        },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1306,6 +1338,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/backo2": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+            "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==",
+            "license": "MIT"
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -2179,6 +2217,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/eventemitter3": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+            "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+            "license": "MIT"
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2517,17 +2561,11 @@
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
             }
         },
-        "node_modules/graphql-request": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-7.2.0.tgz",
-            "integrity": "sha512-0GR7eQHBFYz372u9lxS16cOtEekFlZYB2qOyq8wDvzRmdRSJ0mgUVX1tzNcIzk3G+4NY+mGtSz411wZdeDF/+A==",
-            "license": "MIT",
-            "dependencies": {
-                "@graphql-typed-document-node/core": "^3.2.0"
-            },
-            "peerDependencies": {
-                "graphql": "14 - 16"
-            }
+        "node_modules/graphql-query-batcher": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/graphql-query-batcher/-/graphql-query-batcher-1.0.1.tgz",
+            "integrity": "sha512-NGntvsC2R6c+yqOiMfKXZL3/PpQUIpy70RgroPXRcuDJ1wxJJFesJAEu3Wv5gLbOpr/xPqXCMw2yTGHbqs8uqQ==",
+            "license": "MIT"
         },
         "node_modules/graphql-tag": {
             "version": "2.12.6",
@@ -3134,6 +3172,22 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/isomorphic-unfetch": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+            "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "node-fetch": "^2.6.1",
+                "unfetch": "^4.2.0"
+            }
+        },
+        "node_modules/iterall": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+            "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+            "license": "MIT"
+        },
         "node_modules/jpeg-js": {
             "version": "0.4.4",
             "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
@@ -3235,6 +3289,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/lodash": {
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "license": "MIT"
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -3368,6 +3428,26 @@
             "integrity": "sha512-Jx5lPaaLdIaOsj2mVLWMWulXF6GQVdyLvNSxmiYCvZ8Ma2hfKX0POoR2kgKOqz+oFsRreq0yYZjQ2wjE9VNzCA==",
             "engines": {
                 "node": ">=v0.6.5"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
             }
         },
         "node_modules/object-inspect": {
@@ -4050,13 +4130,12 @@
             }
         },
         "node_modules/stashapp-api": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/stashapp-api/-/stashapp-api-0.2.3.tgz",
-            "integrity": "sha512-4LkOzdfCOsQxKCR7MhDkp3QLpfcUlrQZYrBNAg8LrRflfbeUwc7PXcR3FkBcWfK8owCjgDD+8cHcdpXIu4uYvw==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stashapp-api/-/stashapp-api-1.0.0.tgz",
+            "integrity": "sha512-5rQdXwfCv9OD8SG4ig6nTuyEbBxZEVrGujMlun4IWu9fBfDgdxuqbyzwG7nhrBnjAp7CNiGP5cU08W8A6Nb+zQ==",
             "license": "MIT",
             "dependencies": {
-                "graphql": "^16.11.0",
-                "graphql-request": "^7.2.0"
+                "@genql/runtime": "^2.10.0"
             }
         },
         "node_modules/stop-iteration-iterator": {
@@ -4202,6 +4281,23 @@
             ],
             "license": "MIT"
         },
+        "node_modules/subscriptions-transport-ws": {
+            "version": "0.9.19",
+            "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
+            "integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
+            "deprecated": "The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md",
+            "license": "MIT",
+            "dependencies": {
+                "backo2": "^1.0.2",
+                "eventemitter3": "^3.1.0",
+                "iterall": "^1.2.1",
+                "symbol-observable": "^1.0.4",
+                "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+            },
+            "peerDependencies": {
+                "graphql": ">=0.10.0"
+            }
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4226,6 +4322,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/symbol-observable": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/terminal-kit": {
@@ -4259,6 +4364,12 @@
             "engines": {
                 "node": ">=8.0"
             }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
         },
         "node_modules/tree-kit": {
             "version": "0.8.8",
@@ -4485,7 +4596,12 @@
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
             "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-            "devOptional": true,
+            "license": "MIT"
+        },
+        "node_modules/unfetch": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+            "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==",
             "license": "MIT"
         },
         "node_modules/uniq": {
@@ -4504,12 +4620,37 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/utility-types": {
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+            "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
         "node_modules/v8-compile-cache-lib": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
             "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -4640,6 +4781,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ws": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+            "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+            "license": "MIT",
+            "dependencies": {
+                "async-limiter": "~1.0.0"
+            }
+        },
         "node_modules/yn": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -4674,6 +4824,28 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/zen-observable": {
+            "version": "0.8.15",
+            "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+            "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+            "license": "MIT"
+        },
+        "node_modules/zen-observable-ts": {
+            "version": "0.8.21",
+            "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.21.tgz",
+            "integrity": "sha512-Yj3yXweRc8LdRMrCC8nIc4kkjWecPAUVh0TI0OUrWXx6aX790vLcDlWca6I4vsyCGH3LpWxq0dJRcMOFoVqmeg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^1.9.3",
+                "zen-observable": "^0.8.0"
+            }
+        },
+        "node_modules/zen-observable-ts/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+            "license": "0BSD"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "filesize": "^10.1.6",
         "graphql-tag": "^2.12.6",
         "humanize-duration": "^3.32.1",
-        "stashapp-api": "^0.2.2",
+        "stashapp-api": "^1.0.0",
         "terminal-kit": "^3.1.2"
     },
     "devDependencies": {

--- a/src/controllers/analyzePerformers.ts
+++ b/src/controllers/analyzePerformers.ts
@@ -1,4 +1,4 @@
-import { CriterionModifier, GenderEnum, Performer } from "stashapp-api";
+import { Performer } from "stashapp-api";
 import { buildMenu } from "../commands/menus/buildMenu.js";
 import { getAnalyzeMenuItems } from "../commands/menus/menuItems.js";
 import { getStashInstance } from "../stash.js";
@@ -34,30 +34,44 @@ export const analyzePerformersController = async () => {
     const finishQuerying = await loadingText("Querying your Stash instance");
 
     const {
-        findPerformers: { count, performers } = { count: 0, performers: [] },
-    } = await stash.findPerformers({
-        filter: {
-            per_page: -1,
-        },
-        performer_filter: {
-            gender: {
-                modifier: CriterionModifier.Equals,
-                value: gender.toUpperCase() as (typeof GenderEnum)[keyof typeof GenderEnum],
+        findPerformers: { count, performers: rawPerformers } = { count: 0, performers: [] },
+    } = await stash.query({
+        findPerformers: {
+            __args: {
+                filter: {
+                    per_page: -1,
+                },
+                performer_filter: {
+                    gender: {
+                        modifier: 'EQUALS',
+                        value: gender.toUpperCase() as 'MALE' | 'FEMALE',
+                    },
+                    scene_count: {
+                        modifier: 'GREATER_THAN',
+                        value: sceneCountMin - 1,
+                    },
+                },
             },
-            scene_count: {
-                modifier: CriterionModifier.GreaterThan,
-                value: sceneCountMin - 1,
+            count: true,
+            performers: {
+                id: true,
+                name: true,
+                gender: true,
+                o_counter: true,
+                scene_count: true,
+                favorite: true,
+                scenes: { id: true, o_counter: true },
             },
         },
     });
+
+    const performers = rawPerformers as unknown as Performer[];
 
     finishQuerying(`\nSuccess! Found ${count} matching Performers.`);
 
     const finishAnalyzing = await loadingText("\nPerforming analysis");
 
-    const performersHydrated = hydratePerformersWithMetadata(
-        performers as Performer[]
-    );
+    const performersHydrated = hydratePerformersWithMetadata(performers);
 
     const performersCumTo = [...performersHydrated].filter((performer) => {
         return (

--- a/src/controllers/analyzeStudios.ts
+++ b/src/controllers/analyzeStudios.ts
@@ -1,5 +1,4 @@
 import chalk from "chalk";
-import { CriterionModifier } from "stashapp-api";
 import { buildMenu } from "../commands/menus/buildMenu.js";
 import { getAnalyzeMenuItems } from "../commands/menus/menuItems.js";
 import { getStashInstance } from "../stash.js";
@@ -22,9 +21,20 @@ export const analyzeStudiosController = async () => {
     // Fetch all studios using stash instance
     const {
         findStudios: { count, studios },
-    } = await stash.findStudios({
-        filter: {
-            per_page: -1,
+    } = await stash.query({
+        findStudios: {
+            __args: {
+                filter: {
+                    per_page: -1,
+                },
+            },
+            count: true,
+            studios: {
+                id: true,
+                name: true,
+                scene_count: true,
+                performer_count: true,
+            },
         },
     });
     console.log(chalk.green("Found", count, "Studios containing at least one Scene."));
@@ -35,14 +45,24 @@ export const analyzeStudiosController = async () => {
         // Fetch scenes for each studio using stash instance
         const {
             findScenes: { count: sceneCount, filesize, scenes },
-        } = await stash.findScenes({
-            filter: {
-                per_page: -1,
-            },
-            scene_filter: {
-                studios: {
-                    modifier: CriterionModifier.Includes,
-                    value: [studio.id],
+        } = await stash.query({
+            findScenes: {
+                __args: {
+                    filter: {
+                        per_page: -1,
+                    },
+                    scene_filter: {
+                        studios: {
+                            modifier: "INCLUDES",
+                            value: [studio.id],
+                        },
+                    },
+                },
+                count: true,
+                filesize: true,
+                scenes: {
+                    id: true,
+                    o_counter: true,
                 },
             },
         });

--- a/src/controllers/copyFiles.ts
+++ b/src/controllers/copyFiles.ts
@@ -1,5 +1,4 @@
 import os from "os";
-import { CriterionModifier } from "stashapp-api";
 import { buildMenu } from "../commands/menus/buildMenu.js";
 import { getManageFilesMenuItems } from "../commands/menus/menuItems.js";
 import { quitCommand } from "../commands/quit.js";
@@ -62,8 +61,11 @@ export const copyFilesController = async (): Promise<void> => {
 
     // Simulate tag selection (replace with actual tags from stash if available)
     const stash = getStashInstance();
-    const { findTags: { tags = [] } = {} } = await stash.findTags({
-        filter: { per_page: -1 },
+    const { findTags: { tags = [] } = {} } = await stash.query({
+        findTags: {
+            __args: { filter: { per_page: -1 } },
+            tags: { id: true, name: true },
+        },
     });
     const tagChoices = tags.map((tag: any) => ({ text: tag.name }));
     const { selectedIndexes } = await checkboxMenu(tagChoices);
@@ -72,14 +74,29 @@ export const copyFilesController = async (): Promise<void> => {
     const finishQuerying = await loadingText("Querying your Stash instance");
     const {
         findScenes: { count, filesize, scenes },
-    } = (await stash.findScenes({
-        filter: {
-            per_page: -1,
-        },
-        scene_filter: {
-            tags: {
-                modifier: CriterionModifier.Includes,
-                value: tagIDs.map(String),
+    } = (await stash.query({
+        findScenes: {
+            __args: {
+                filter: {
+                    per_page: -1,
+                },
+                scene_filter: {
+                    tags: {
+                        modifier: 'INCLUDES',
+                        value: tagIDs.map(String),
+                    },
+                },
+            },
+            count: true,
+            filesize: true,
+            scenes: {
+                id: true,
+                title: true,
+                studio: { name: true },
+                performers: { name: true, gender: true, o_counter: true },
+                files: { path: true, basename: true, size: true },
+                paths: { screenshot: true },
+                tags: { name: true },
             },
         },
     })) as any;

--- a/src/controllers/organizeLibrary.ts
+++ b/src/controllers/organizeLibrary.ts
@@ -1,8 +1,7 @@
 import fs from "fs";
 import path from "path";
 import chalk from "chalk";
-import { GenderEnum, Scene, SceneFilterType, Studio } from "stashapp-api";
-import { CriterionModifier } from "stashapp-api/dist/generated/graphql.js";
+import type { Scene, SceneFilterType, Studio } from "stashapp-api";
 import { backCommand } from "../commands/back.js";
 import { buildMenu } from "../commands/menus/buildMenu.js";
 import { getManageFilesMenuItems } from "../commands/menus/menuItems.js";
@@ -63,19 +62,38 @@ export const organizeLibraryController = async () => {
 
     if (!organizationDetails) return;
 
-    const { findScenes } = await stash.findScenes({
-        filter: {
-            per_page: -1,
-        },
-        scene_filter: {
-            ...organizationDetails.sceneFilter,
+    const { findScenes } = await stash.query({
+        findScenes: {
+            __args: {
+                filter: {
+                    per_page: -1,
+                },
+                scene_filter: {
+                    ...organizationDetails.sceneFilter,
+                },
+            },
+            count: true,
+            scenes: {
+                id: true,
+                title: true,
+                rating100: true,
+                o_counter: true,
+                date: true,
+                studio: { id: true, name: true },
+                performers: { id: true, name: true, gender: true },
+                tags: { id: true, name: true },
+                files: { path: true, basename: true, size: true },
+            },
         },
     });
 
     const {
         findStudios: { studios },
-    } = await stash.findStudios({
-        filter: { per_page: -1 },
+    } = await stash.query({
+        findStudios: {
+            __args: { filter: { per_page: -1 } },
+            studios: { id: true, name: true, parent_studio: { id: true, name: true } },
+        },
     });
 
     // Build scenesToOrganize and filter out duplicates by newFilepath
@@ -159,7 +177,12 @@ export const organizeLibraryController = async () => {
     // Call organizeScenes with scenes array and dry run selection
     const results = organizeScenes(scenesToOrganize, isDryRun);
 
-    await stash.metadataScan({ input: { paths: null } });
+    await stash.mutation({
+        metadataScan: {
+            __args: { input: {} },
+            __typename: true,
+        },
+    });
 
     // Notify user about scan
     console.log();
@@ -210,11 +233,11 @@ const buildFileName = (
 
     let titleStr = scene.title ?? "";
     let malePerformersStr = performers
-        .filter((p) => p.gender === GenderEnum.Male)
+        .filter((p) => p.gender === 'MALE')
         .map((p) => p.name)
         .join(" ");
     let femalePerformersStr = performers
-        .filter((p) => p.gender === GenderEnum.Female)
+        .filter((p) => p.gender === 'FEMALE')
         .map((p) => p.name)
         .join(" ");
     let tagsStr = tags.map((t) => t.name).join(" ");
@@ -297,10 +320,10 @@ const filterScenesByPerformerSelections = (
 
     return scenes.filter((scene) => {
         const hasMalePerformer = scene.performers.some(
-            (p) => p.gender === GenderEnum.Male
+            (p) => p.gender === 'MALE'
         );
         const hasFemalePerformer = scene.performers.some(
-            (p) => p.gender === GenderEnum.Female
+            (p) => p.gender === 'FEMALE'
         );
 
         if (maleFilter && femaleFilter)
@@ -703,7 +726,7 @@ const getUserOrganizationDetails =
                     checked: isStashIDFilterLocked,
                     disabled: isStashIDFilterLocked,
                     sceneFilter: {
-                        id: { modifier: CriterionModifier.NotNull, value: 0 },
+                        id: { modifier: 'NOT_NULL', value: 0 },
                     },
                 },
                 {
@@ -712,7 +735,7 @@ const getUserOrganizationDetails =
                     disabled: isStudioFilterLocked,
                     sceneFilter: {
                         studios: {
-                            modifier: CriterionModifier.NotNull,
+                            modifier: 'NOT_NULL',
                             value: [""],
                         },
                     },
@@ -723,7 +746,7 @@ const getUserOrganizationDetails =
                     disabled: isTitleFilterLocked,
                     sceneFilter: {
                         title: {
-                            modifier: CriterionModifier.NotNull,
+                            modifier: 'NOT_NULL',
                             value: "",
                         },
                     },
@@ -734,7 +757,7 @@ const getUserOrganizationDetails =
                     disabled: false,
                     sceneFilter: {
                         date: {
-                            modifier: CriterionModifier.NotNull,
+                            modifier: 'NOT_NULL',
                             value: "",
                         },
                     },
@@ -745,7 +768,7 @@ const getUserOrganizationDetails =
                     disabled: false,
                     sceneFilter: {
                         details: {
-                            modifier: CriterionModifier.NotNull,
+                            modifier: 'NOT_NULL',
                             value: "",
                         },
                     },
@@ -758,7 +781,7 @@ const getUserOrganizationDetails =
                         performerGender === "Male",
                     sceneFilter: {
                         performer_count: {
-                            modifier: CriterionModifier.GreaterThan,
+                            modifier: 'GREATER_THAN',
                             value: 0,
                         },
                     },
@@ -771,7 +794,7 @@ const getUserOrganizationDetails =
                         performerGender === "Female",
                     sceneFilter: {
                         performer_count: {
-                            modifier: CriterionModifier.GreaterThan,
+                            modifier: 'GREATER_THAN',
                             value: 0,
                         },
                     },
@@ -782,7 +805,7 @@ const getUserOrganizationDetails =
                     disabled: false,
                     sceneFilter: {
                         tag_count: {
-                            modifier: CriterionModifier.GreaterThan,
+                            modifier: 'GREATER_THAN',
                             value: 0,
                         },
                     },
@@ -793,7 +816,7 @@ const getUserOrganizationDetails =
                     disabled: false,
                     sceneFilter: {
                         o_counter: {
-                            modifier: CriterionModifier.GreaterThan,
+                            modifier: 'GREATER_THAN',
                             value: 0,
                         },
                     },

--- a/src/controllers/rateStashController.ts
+++ b/src/controllers/rateStashController.ts
@@ -17,8 +17,6 @@
 
 import chalk from "chalk";
 import {
-    CriterionModifier,
-    GenderEnum,
     Performer,
     Scene,
     Studio,
@@ -92,10 +90,10 @@ const updateScenesWithRatings = async (
     // even though we have a bulk update method, it only supports one rating for all scenes
     for (const scene of scenesToUpdate) {
         try {
-            await stash.sceneUpdate({
-                input: {
-                    id: scene.id,
-                    rating100: scene.rating,
+            await stash.mutation({
+                sceneUpdate: {
+                    __args: { input: { id: scene.id, rating100: scene.rating } },
+                    id: true,
                 },
             });
             progressBar.update();
@@ -123,10 +121,10 @@ const updatePerformersWithRatings = async (
 
     for (const performer of performersToUpdate) {
         try {
-            await stash.performerUpdate({
-                input: {
-                    id: performer.id,
-                    rating100: performer.rating,
+            await stash.mutation({
+                performerUpdate: {
+                    __args: { input: { id: performer.id, rating100: performer.rating } },
+                    id: true,
                 },
             });
             progressBar.update();
@@ -156,10 +154,10 @@ const updateStudiosWithRatings = async (
 
     for (const studio of studiosToUpdate) {
         try {
-            await stash.studioUpdate({
-                input: {
-                    id: studio.id,
-                    rating100: studio.rating,
+            await stash.mutation({
+                studioUpdate: {
+                    __args: { input: { id: studio.id, rating100: studio.rating } },
+                    id: true,
                 },
             });
             progressBar.update();
@@ -265,9 +263,17 @@ export const rateStashController = async () => {
     let finishLoading = await loadingText("Loading Scenes...");
     const {
         findScenes: { scenes },
-    } = await stash.findScenes({
-        filter: {
-            per_page: -1,
+    } = await stash.query({
+        findScenes: {
+            __args: { filter: { per_page: -1 } },
+            scenes: {
+                id: true, title: true, rating100: true, o_counter: true, date: true, details: true,
+                studio: { id: true, name: true, rating100: true },
+                performers: { id: true, name: true, gender: true, o_counter: true, rating100: true, favorite: true, scene_count: true },
+                tags: { id: true, name: true, favorite: true, rating100: true },
+                files: { path: true, basename: true, size: true },
+            },
+            count: true,
         },
     });
     finishLoading();
@@ -275,19 +281,20 @@ export const rateStashController = async () => {
     finishLoading = await loadingText("Loading Male Performers...");
     const {
         findPerformers: { performers: malePerformers },
-    } = await stash.findPerformers({
-        filter: {
-            per_page: -1,
-        },
-        performer_filter: {
-            gender: {
-                modifier: CriterionModifier.Equals,
-                value: GenderEnum.Male,
+    } = await stash.query({
+        findPerformers: {
+            __args: {
+                filter: { per_page: -1 },
+                performer_filter: {
+                    gender: { modifier: 'EQUALS', value: 'MALE' },
+                    scene_count: { modifier: 'GREATER_THAN', value: 0 },
+                },
             },
-            scene_count: {
-                modifier: CriterionModifier.GreaterThan,
-                value: 0,
+            performers: {
+                id: true, name: true, gender: true, rating100: true, o_counter: true, scene_count: true, favorite: true,
+                scenes: { id: true, o_counter: true },
             },
+            count: true,
         },
     });
     finishLoading();
@@ -295,23 +302,21 @@ export const rateStashController = async () => {
     finishLoading = await loadingText("Loading Female Performers...");
     const {
         findPerformers: { performers: femalePerformers },
-    } = await stash.findPerformers({
-        filter: {
-            per_page: -1,
-        },
-        performer_filter: {
-            gender: {
-                modifier: CriterionModifier.Equals,
-                value: GenderEnum.Female,
+    } = await stash.query({
+        findPerformers: {
+            __args: {
+                filter: { per_page: -1 },
+                performer_filter: {
+                    gender: { modifier: 'EQUALS', value: 'FEMALE' },
+                    o_counter: { modifier: 'GREATER_THAN', value: 0 },
+                    scene_count: { modifier: 'GREATER_THAN', value: 0 },
+                },
             },
-            o_counter: {
-                modifier: CriterionModifier.GreaterThan,
-                value: 0,
+            performers: {
+                id: true, name: true, gender: true, rating100: true, o_counter: true, scene_count: true, favorite: true,
+                scenes: { id: true, o_counter: true },
             },
-            scene_count: {
-                modifier: CriterionModifier.GreaterThan,
-                value: 0,
-            },
+            count: true,
         },
     });
     finishLoading();
@@ -320,13 +325,18 @@ export const rateStashController = async () => {
 
     const {
         findStudios: { studios },
-    } = await stash.findStudios({
-        filter: { per_page: -1 },
-        studio_filter: {
-            scene_count: {
-                modifier: CriterionModifier.GreaterThan,
-                value: 0,
+    } = await stash.query({
+        findStudios: {
+            __args: {
+                filter: { per_page: -1 },
+                studio_filter: {
+                    scene_count: { modifier: 'GREATER_THAN', value: 0 },
+                },
             },
+            studios: {
+                id: true, name: true, rating100: true, o_counter: true, scene_count: true, favorite: true,
+            },
+            count: true,
         },
     });
     finishLoading();
@@ -334,15 +344,18 @@ export const rateStashController = async () => {
     finishLoading = await loadingText("Loading Tags...");
     const {
         findTags: { tags },
-    } = await stash.findTags({
-        filter: {
-            per_page: -1,
-        },
-        tag_filter: {
-            scene_count: {
-                modifier: CriterionModifier.GreaterThan,
-                value: 0,
+    } = await stash.query({
+        findTags: {
+            __args: {
+                filter: { per_page: -1 },
+                tag_filter: {
+                    scene_count: { modifier: 'GREATER_THAN', value: 0 },
+                },
             },
+            tags: {
+                id: true, name: true, rating100: true, scene_count: true, favorite: true,
+            },
+            count: true,
         },
     });
     finishLoading();
@@ -360,10 +373,17 @@ export const rateStashController = async () => {
     console.log(chalk.green(`Scenes found:    ${scenes.length}`));
     console.log(chalk.gray("----------------------------------------"));
 
+    // Cast narrowed GenQL types to full types at the boundary
+    const allScenes = scenes as unknown as Scene[];
+    const allStudios = studios as unknown as Studio[];
+    const allTags = tags as unknown as Tag[];
+    const allMalePerformers = malePerformers as unknown as Performer[];
+    const allFemalePerformers = femalePerformers as unknown as Performer[];
+
     const ratedStudios: ArtifactRated[] = rateArtifacts(
         "studio",
-        studios as Studio[],
-        scenes.filter((scene) => scene.studio?.id) as Scene[]
+        allStudios,
+        allScenes.filter((scene) => scene.studio?.id)
     );
 
     logArtifactRatings(ratedStudios, "Studios");
@@ -378,8 +398,8 @@ export const rateStashController = async () => {
 
     const ratedTags: ArtifactRated[] = rateArtifacts(
         "tag",
-        tags as Tag[],
-        scenes.filter((scene) => scene.tags?.length) as Scene[]
+        allTags,
+        allScenes.filter((scene) => scene.tags?.length)
     );
 
     logArtifactRatings(ratedTags, "Tags");
@@ -387,10 +407,10 @@ export const rateStashController = async () => {
 
     const ratedMalePerformers: ArtifactRated[] = rateArtifacts(
         "performer",
-        malePerformers as Performer[],
-        scenes.filter((scene) =>
-            scene.performers?.some((p) => p.gender === GenderEnum.Male)
-        ) as Scene[]
+        allMalePerformers,
+        allScenes.filter((scene) =>
+            scene.performers?.some((p) => p.gender === 'MALE')
+        )
     );
 
     logArtifactRatings(ratedMalePerformers, "Male Performers");
@@ -405,10 +425,10 @@ export const rateStashController = async () => {
 
     const ratedFemalePerformers: ArtifactRated[] = rateArtifacts(
         "performer",
-        femalePerformers as Performer[],
-        scenes.filter((scene) =>
-            scene.performers?.some((p) => p.gender === GenderEnum.Female)
-        ) as Scene[]
+        allFemalePerformers,
+        allScenes.filter((scene) =>
+            scene.performers?.some((p) => p.gender === 'FEMALE')
+        )
     );
 
     logArtifactRatings(ratedFemalePerformers, "Female Performers");
@@ -422,7 +442,7 @@ export const rateStashController = async () => {
     );
 
     const ratedScenes: SceneRated[] = rateScenes(
-        scenes as Scene[],
+        allScenes,
         ratedStudios as StudioRated[],
         ratedTags as TagRated[],
         [...ratedMalePerformers, ...ratedFemalePerformers] as PerformerRated[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { StashApp } from "stashapp-api";
+import { StashClient } from "stashapp-api";
 import { buildMenu } from "./commands/menus/buildMenu.js";
 import { getMainMenuItems } from "./commands/menus/menuItems.js";
 import { loadConfig, promptForConfig, saveConfigToEnv } from "./config.js";
@@ -15,7 +15,7 @@ export const start = async () => {
         process.env.STASH_API_KEY = config.apiKey;
     }
 
-    const stash = StashApp.init({ url: config.url, apiKey: config.apiKey });
+    const stash = new StashClient({ url: config.url, apiKey: config.apiKey });
     setStashInstance(stash);
 
     buildMenu(getMainMenuItems());

--- a/src/stash.ts
+++ b/src/stash.ts
@@ -1,15 +1,15 @@
-import { StashApp } from "stashapp-api";
+import { StashClient } from "stashapp-api";
 
-let stashInstance: StashApp | null = null;
+let stashInstance: StashClient | null = null;
 
-export function setStashInstance(instance: StashApp) {
+export function setStashInstance(instance: StashClient) {
     stashInstance = instance;
 }
 
-export function getStashInstance(): StashApp {
+export function getStashInstance(): StashClient {
     if (!stashInstance) {
         throw new Error(
-            "StashApp instance not initialized. Call setStashInstance() first."
+            "StashClient instance not initialized. Call setStashInstance() first."
         );
     }
     return stashInstance;

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -8,9 +8,9 @@ interface SortOptions {
     secondarySortBy?: string;
 }
 
-export const sortArrayOfObjects = <T extends Record<string, unknown>>(
+export const sortArrayOfObjects = <T>(
     arr: T[],
-    sortBy: string,
+    sortBy: keyof T & string,
     options: SortOptions = {}
 ): T[] => {
     const _options = {
@@ -23,8 +23,8 @@ export const sortArrayOfObjects = <T extends Record<string, unknown>>(
     return [...arr].sort((a, b) => {
         const aVal = Number(a[sortBy]);
         const bVal = Number(b[sortBy]);
-        const aSecondary = Number(a[secondarySortBy]);
-        const bSecondary = Number(b[secondarySortBy]);
+        const aSecondary = Number((a as Record<string, unknown>)[secondarySortBy]);
+        const bSecondary = Number((b as Record<string, unknown>)[secondarySortBy]);
 
         if (direction === "ASC") {
             return aVal - bVal || aSecondary - bSecondary;

--- a/src/utils/scenes.ts
+++ b/src/utils/scenes.ts
@@ -1,6 +1,4 @@
 import {
-    CriterionModifier,
-    GenderEnum,
     Performer,
     Scene,
     Studio,
@@ -27,19 +25,19 @@ export const addScenesToFillSpace = async (
     };
 
     print("Your favorite Female Performers are:", "yellow");
-    rotatingColors(flattenByKey(favorites.femalePerformers, "name"));
+    rotatingColors(flattenByKey(favorites.femalePerformers, "name") as string[]);
     print("\n\n");
 
     print("Your favorite Male Performers are:", "yellow");
-    rotatingColors(flattenByKey(favorites.malePerformers, "name"));
+    rotatingColors(flattenByKey(favorites.malePerformers, "name") as string[]);
     print("\n\n");
 
     print("Your favorite Studios are:", "yellow");
-    rotatingColors(flattenByKey(favorites.studios, "name"));
+    rotatingColors(flattenByKey(favorites.studios, "name") as string[]);
     print("\n\n");
 
     print("Your favorite Tags are:", "yellow");
-    rotatingColors(flattenByKey(favorites.tags, "name"));
+    rotatingColors(flattenByKey(favorites.tags, "name") as string[]);
     print("\n\n");
 
     print(
@@ -48,45 +46,70 @@ export const addScenesToFillSpace = async (
     );
     let clearLoading = await loadingText("Calculating, maybe fapping a little");
 
+    const sceneFields = {
+        id: true, title: true, rating100: true, o_counter: true,
+        studio: { id: true, name: true },
+        performers: { id: true, name: true, gender: true, o_counter: true, favorite: true },
+        tags: { id: true, name: true, favorite: true },
+        files: { path: true, basename: true, size: true },
+        paths: { screenshot: true },
+        date: true, details: true,
+    } as const;
+
     const favoriteStudioIDs = flattenByKey(favorites.studios, "id").map(String);
     const {
         findScenes: { scenes: scenesFromFavoriteStudios } = { scenes: [] },
-    } = await stash.findScenes({
-        filter: { per_page: -1 },
-        scene_filter: {
-            studios: {
-                modifier: CriterionModifier.Includes,
-                value: favoriteStudioIDs,
+    } = await stash.query({
+        findScenes: {
+            __args: {
+                filter: { per_page: -1 },
+                scene_filter: {
+                    studios: {
+                        modifier: 'INCLUDES',
+                        value: favoriteStudioIDs,
+                    },
+                    o_counter: {
+                        modifier: 'GREATER_THAN',
+                        value: 0,
+                    },
+                },
             },
-            o_counter: {
-                modifier: CriterionModifier.GreaterThan,
-                value: 0,
-            },
+            scenes: sceneFields,
         },
     });
 
     const favoriteTagIDs = flattenByKey(favorites.tags, "id").map(String);
     const { findScenes: { scenes: scenesFromFavoriteTags } = { scenes: [] } } =
-        await stash.findScenes({
-            filter: { per_page: -1 },
-            scene_filter: {
-                tags: {
-                    modifier: CriterionModifier.Includes,
-                    value: favoriteTagIDs,
+        await stash.query({
+            findScenes: {
+                __args: {
+                    filter: { per_page: -1 },
+                    scene_filter: {
+                        tags: {
+                            modifier: 'INCLUDES',
+                            value: favoriteTagIDs,
+                        },
+                        o_counter: {
+                            modifier: 'GREATER_THAN',
+                            value: 0,
+                        },
+                    },
                 },
-                o_counter: {
-                    modifier: CriterionModifier.GreaterThan,
-                    value: 0,
-                },
+                scenes: sceneFields,
             },
         });
 
     const {
         findScenes: { scenes: scenesFromFavoritePerformers } = { scenes: [] },
-    } = await stash.findScenes({
-        filter: { per_page: -1 },
-        scene_filter: {
-            performer_favorite: true,
+    } = await stash.query({
+        findScenes: {
+            __args: {
+                filter: { per_page: -1 },
+                scene_filter: {
+                    performer_favorite: true,
+                },
+            },
+            scenes: sceneFields,
         },
     });
 
@@ -151,13 +174,18 @@ const getAllStashData = async () => {
     let clearLoading = await loadingText("Getting female Performers");
     const {
         findPerformers: { performers: femalePerformers } = { performers: [] },
-    } = await stash.findPerformers({
-        filter: { per_page: -1 },
-        performer_filter: {
-            gender: {
-                modifier: CriterionModifier.Equals,
-                value: GenderEnum.Female,
+    } = await stash.query({
+        findPerformers: {
+            __args: {
+                filter: { per_page: -1 },
+                performer_filter: {
+                    gender: {
+                        modifier: 'EQUALS',
+                        value: 'FEMALE',
+                    },
+                },
             },
+            performers: { id: true, name: true, gender: true, o_counter: true, scene_count: true, favorite: true, rating100: true, scenes: { id: true, o_counter: true } },
         },
     });
     clearLoading("Done");
@@ -165,33 +193,46 @@ const getAllStashData = async () => {
     clearLoading = await loadingText("Getting male Performers");
     const {
         findPerformers: { performers: malePerformers } = { performers: [] },
-    } = await stash.findPerformers({
-        filter: { per_page: -1 },
-        performer_filter: {
-            gender: {
-                modifier: CriterionModifier.Equals,
-                value: GenderEnum.Male,
+    } = await stash.query({
+        findPerformers: {
+            __args: {
+                filter: { per_page: -1 },
+                performer_filter: {
+                    gender: {
+                        modifier: 'EQUALS',
+                        value: 'MALE',
+                    },
+                },
             },
+            performers: { id: true, name: true, gender: true, o_counter: true, scene_count: true, favorite: true, rating100: true, scenes: { id: true, o_counter: true } },
         },
     });
     clearLoading("Done");
 
     clearLoading = await loadingText("Getting Studios");
     const { findStudios: { studios } = { studios: [] } } =
-        await stash.findStudios({ filter: { per_page: -1 } });
+        await stash.query({
+            findStudios: {
+                __args: { filter: { per_page: -1 } },
+                studios: { id: true, name: true, favorite: true, rating100: true, o_counter: true },
+            },
+        });
     clearLoading("Done");
 
     clearLoading = await loadingText("Getting Tags");
-    const { findTags: { tags } = { tags: [] } } = await stash.findTags({
-        filter: { per_page: -1 },
+    const { findTags: { tags } = { tags: [] } } = await stash.query({
+        findTags: {
+            __args: { filter: { per_page: -1 } },
+            tags: { id: true, name: true, favorite: true, rating100: true },
+        },
     });
     clearLoading("Done");
 
     return {
-        femalePerformers,
-        malePerformers,
-        studios,
-        tags,
+        femalePerformers: femalePerformers as unknown as Performer[],
+        malePerformers: malePerformers as unknown as Performer[],
+        studios: studios as unknown as Studio[],
+        tags: tags as unknown as Tag[],
     };
 };
 
@@ -212,14 +253,14 @@ export const getTotalSize = (scenes: Scene[]): number => {
 
 const getVideoFileSize = (scene: Scene): number => {
     const [videoFile] = scene.files;
-    return videoFile.size;
+    return Number(videoFile.size);
 };
 
 const filterFavorites = <T extends { favorite?: boolean }>(arr: T[]): T[] => {
     return arr.filter(({ favorite }) => Boolean(favorite));
 };
 
-const flattenByKey = <T extends Record<string, unknown>>(arr: T[], key: keyof T): T[keyof T][] => {
+const flattenByKey = <T, K extends keyof T>(arr: T[], key: K): T[K][] => {
     return arr.map((item) => item[key]);
 };
 


### PR DESCRIPTION
## Summary
- Migrate all API calls from old method-based interface to GenQL query/mutation pattern
- Replace `StashApp.init()` with `new StashClient()`
- All queries now use explicit field selection (`{ id: true, name: true, ... }`)
- All mutations use `stash.mutation({ xUpdate: { __args: { input }, ...fields } })`
- Enum values replaced with string literals (`'EQUALS'`, `'MALE'`, etc.)
- Remove broken internal import from `stashapp-api/dist/generated/graphql.js`

## Notes
GenQL returns narrowed `Pick<>` types based on field selection. These don't satisfy full interface types (`Scene`, `Performer`, etc.) used in utility functions. Cast at query boundaries with `as unknown as Scene[]` for now. A future refactor could adopt narrowed types throughout.

Closes #12