### PR TITLE
chore: bump stashapp-api to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "filesize": "^10.1.6",
                 "graphql-tag": "^2.12.6",
                 "humanize-duration": "^3.32.1",
-                "stashapp-api": "^1.0.0",
+                "stashapp-api": "^1.0.1",
                 "terminal-kit": "^3.1.2"
             },
             "devDependencies": {
@@ -5315,9 +5315,9 @@
             "license": "MIT"
         },
         "node_modules/stashapp-api": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/stashapp-api/-/stashapp-api-1.0.0.tgz",
-            "integrity": "sha512-5rQdXwfCv9OD8SG4ig6nTuyEbBxZEVrGujMlun4IWu9fBfDgdxuqbyzwG7nhrBnjAp7CNiGP5cU08W8A6Nb+zQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/stashapp-api/-/stashapp-api-1.0.1.tgz",
+            "integrity": "sha512-M1Bn7qRoOMEoEgTG7TyVKUDU+K04LYkSXH03j8QjPLhKp7Pc3L1ERvso07+jy6M2nyNvlbklzs5VHst00T5nBA==",
             "license": "MIT",
             "dependencies": {
                 "@genql/runtime": "^2.10.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "filesize": "^10.1.6",
         "graphql-tag": "^2.12.6",
         "humanize-duration": "^3.32.1",
-        "stashapp-api": "^1.0.0",
+        "stashapp-api": "^1.0.1",
         "terminal-kit": "^3.1.2"
     },
     "devDependencies": {


### PR DESCRIPTION
Picks up scalar selection presets and documentation improvements.