### PR TITLE
fix: operator precedence in o_counter filter

### DIFF
--- a/src/utils/rating.ts
+++ b/src/utils/rating.ts
@@ -95,7 +95,7 @@ export const rateScenes = (
     ratedTags: TagRated[],
     ratedPerformers: PerformerRated[]
 ): SceneRated[] => {
-    const likedScenes = scenes.filter((scene) => scene?.o_counter ?? 0 > 0);
+    const likedScenes = scenes.filter((scene) => (scene?.o_counter ?? 0) > 0);
     const totalLikes = likedScenes.reduce(
         (acc, scene) => acc + (scene?.o_counter ?? 0),
         0
@@ -181,7 +181,7 @@ const getArtifactRating = (
     });
 
     const likedScenes = artifactScenes.filter(
-        (scene) => scene?.o_counter ?? 0 > 0
+        (scene) => (scene?.o_counter ?? 0) > 0
     );
     const totalLikes = likedScenes.reduce(
         (acc, scene) => acc + (scene?.o_counter ?? 0),


### PR DESCRIPTION
## Summary
Fix `?? 0 > 0` → `(?? 0) > 0` in rating.ts. The `>` operator has higher precedence than `??`, so scenes with o_counter=0 were incorrectly passing the "liked scenes" filter.

Closes #23