### PR TITLE
refactor: use stashapp-api field presets

### DIFF
--- a/src/controllers/analyzePerformers.ts
+++ b/src/controllers/analyzePerformers.ts
@@ -1,4 +1,4 @@
-import { Performer } from "stashapp-api";
+import { Performer, PerformerFields } from "stashapp-api";
 import { buildMenu } from "../commands/menus/buildMenu.js";
 import { getAnalyzeMenuItems } from "../commands/menus/menuItems.js";
 import { getStashInstance } from "../stash.js";
@@ -54,18 +54,13 @@ export const analyzePerformersController = async () => {
             },
             count: true,
             performers: {
-                id: true,
-                name: true,
-                gender: true,
-                o_counter: true,
-                scene_count: true,
-                favorite: true,
+                ...PerformerFields,
                 scenes: { id: true, o_counter: true },
             },
         },
     });
 
-    const performers = rawPerformers as unknown as Performer[];
+    const performers = rawPerformers as Performer[];
 
     finishQuerying(`\nSuccess! Found ${count} matching Performers.`);
 

--- a/src/controllers/copyFiles.ts
+++ b/src/controllers/copyFiles.ts
@@ -2,6 +2,7 @@ import os from "os";
 import { buildMenu } from "../commands/menus/buildMenu.js";
 import { getManageFilesMenuItems } from "../commands/menus/menuItems.js";
 import { quitCommand } from "../commands/quit.js";
+import { SceneFields, TagFields } from "stashapp-api";
 import { getStashInstance } from "../stash.js";
 import {
     copyScene,
@@ -64,7 +65,7 @@ export const copyFilesController = async (): Promise<void> => {
     const { findTags: { tags = [] } = {} } = await stash.query({
         findTags: {
             __args: { filter: { per_page: -1 } },
-            tags: { id: true, name: true },
+            tags: { ...TagFields },
         },
     });
     const tagChoices = tags.map((tag: any) => ({ text: tag.name }));
@@ -90,13 +91,9 @@ export const copyFilesController = async (): Promise<void> => {
             count: true,
             filesize: true,
             scenes: {
-                id: true,
-                title: true,
-                studio: { name: true },
-                performers: { name: true, gender: true, o_counter: true },
+                ...SceneFields,
                 files: { path: true, basename: true, size: true },
                 paths: { screenshot: true },
-                tags: { name: true },
             },
         },
     })) as any;

--- a/src/controllers/organizeLibrary.ts
+++ b/src/controllers/organizeLibrary.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import chalk from "chalk";
+import { SceneFields, StudioFields } from "stashapp-api";
 import type { Scene, SceneFilterType, Studio } from "stashapp-api";
 import { backCommand } from "../commands/back.js";
 import { buildMenu } from "../commands/menus/buildMenu.js";
@@ -74,14 +75,7 @@ export const organizeLibraryController = async () => {
             },
             count: true,
             scenes: {
-                id: true,
-                title: true,
-                rating100: true,
-                o_counter: true,
-                date: true,
-                studio: { id: true, name: true },
-                performers: { id: true, name: true, gender: true },
-                tags: { id: true, name: true },
+                ...SceneFields,
                 files: { path: true, basename: true, size: true },
             },
         },
@@ -92,7 +86,7 @@ export const organizeLibraryController = async () => {
     } = await stash.query({
         findStudios: {
             __args: { filter: { per_page: -1 } },
-            studios: { id: true, name: true, parent_studio: { id: true, name: true } },
+            studios: { ...StudioFields, parent_studio: { id: true, name: true } },
         },
     });
 

--- a/src/controllers/rateStashController.ts
+++ b/src/controllers/rateStashController.ts
@@ -18,9 +18,13 @@
 import chalk from "chalk";
 import {
     Performer,
+    PerformerFields,
     Scene,
+    SceneFields,
     Studio,
+    StudioFields,
     Tag,
+    TagFields,
 } from "stashapp-api";
 import { backCommand } from "../commands/back.js";
 import { buildMenu } from "../commands/menus/buildMenu.js";
@@ -267,11 +271,9 @@ export const rateStashController = async () => {
         findScenes: {
             __args: { filter: { per_page: -1 } },
             scenes: {
-                id: true, title: true, rating100: true, o_counter: true, date: true, details: true,
-                studio: { id: true, name: true, rating100: true },
-                performers: { id: true, name: true, gender: true, o_counter: true, rating100: true, favorite: true, scene_count: true },
-                tags: { id: true, name: true, favorite: true, rating100: true },
+                ...SceneFields,
                 files: { path: true, basename: true, size: true },
+                performers: { ...PerformerFields, scenes: { id: true, o_counter: true } },
             },
             count: true,
         },
@@ -291,7 +293,7 @@ export const rateStashController = async () => {
                 },
             },
             performers: {
-                id: true, name: true, gender: true, rating100: true, o_counter: true, scene_count: true, favorite: true,
+                ...PerformerFields,
                 scenes: { id: true, o_counter: true },
             },
             count: true,
@@ -313,7 +315,7 @@ export const rateStashController = async () => {
                 },
             },
             performers: {
-                id: true, name: true, gender: true, rating100: true, o_counter: true, scene_count: true, favorite: true,
+                ...PerformerFields,
                 scenes: { id: true, o_counter: true },
             },
             count: true,
@@ -334,7 +336,7 @@ export const rateStashController = async () => {
                 },
             },
             studios: {
-                id: true, name: true, rating100: true, o_counter: true, scene_count: true, favorite: true,
+                ...StudioFields,
             },
             count: true,
         },
@@ -353,7 +355,7 @@ export const rateStashController = async () => {
                 },
             },
             tags: {
-                id: true, name: true, rating100: true, scene_count: true, favorite: true,
+                ...TagFields,
             },
             count: true,
         },
@@ -373,17 +375,10 @@ export const rateStashController = async () => {
     console.log(chalk.green(`Scenes found:    ${scenes.length}`));
     console.log(chalk.gray("----------------------------------------"));
 
-    // Cast narrowed GenQL types to full types at the boundary
-    const allScenes = scenes as unknown as Scene[];
-    const allStudios = studios as unknown as Studio[];
-    const allTags = tags as unknown as Tag[];
-    const allMalePerformers = malePerformers as unknown as Performer[];
-    const allFemalePerformers = femalePerformers as unknown as Performer[];
-
     const ratedStudios: ArtifactRated[] = rateArtifacts(
         "studio",
-        allStudios,
-        allScenes.filter((scene) => scene.studio?.id)
+        studios as Studio[],
+        scenes as Scene[]
     );
 
     logArtifactRatings(ratedStudios, "Studios");
@@ -398,8 +393,8 @@ export const rateStashController = async () => {
 
     const ratedTags: ArtifactRated[] = rateArtifacts(
         "tag",
-        allTags,
-        allScenes.filter((scene) => scene.tags?.length)
+        tags as Tag[],
+        (scenes as Scene[]).filter((scene) => scene.tags?.length)
     );
 
     logArtifactRatings(ratedTags, "Tags");
@@ -407,8 +402,8 @@ export const rateStashController = async () => {
 
     const ratedMalePerformers: ArtifactRated[] = rateArtifacts(
         "performer",
-        allMalePerformers,
-        allScenes.filter((scene) =>
+        malePerformers as Performer[],
+        (scenes as Scene[]).filter((scene) =>
             scene.performers?.some((p) => p.gender === 'MALE')
         )
     );
@@ -425,8 +420,8 @@ export const rateStashController = async () => {
 
     const ratedFemalePerformers: ArtifactRated[] = rateArtifacts(
         "performer",
-        allFemalePerformers,
-        allScenes.filter((scene) =>
+        femalePerformers as Performer[],
+        (scenes as Scene[]).filter((scene) =>
             scene.performers?.some((p) => p.gender === 'FEMALE')
         )
     );
@@ -442,7 +437,7 @@ export const rateStashController = async () => {
     );
 
     const ratedScenes: SceneRated[] = rateScenes(
-        allScenes,
+        scenes as Scene[],
         ratedStudios as StudioRated[],
         ratedTags as TagRated[],
         [...ratedMalePerformers, ...ratedFemalePerformers] as PerformerRated[]

--- a/src/utils/scenes.ts
+++ b/src/utils/scenes.ts
@@ -1,8 +1,12 @@
 import {
     Performer,
+    PerformerFields,
     Scene,
+    SceneFields,
     Studio,
+    StudioFields,
     Tag,
+    TagFields,
 } from "stashapp-api";
 import { getStashInstance } from "../stash.js";
 import { formatBytes } from "./format.js";
@@ -47,13 +51,9 @@ export const addScenesToFillSpace = async (
     let clearLoading = await loadingText("Calculating, maybe fapping a little");
 
     const sceneFields = {
-        id: true, title: true, rating100: true, o_counter: true,
-        studio: { id: true, name: true },
-        performers: { id: true, name: true, gender: true, o_counter: true, favorite: true },
-        tags: { id: true, name: true, favorite: true },
+        ...SceneFields,
         files: { path: true, basename: true, size: true },
         paths: { screenshot: true },
-        date: true, details: true,
     } as const;
 
     const favoriteStudioIDs = flattenByKey(favorites.studios, "id").map(String);
@@ -113,7 +113,6 @@ export const addScenesToFillSpace = async (
         },
     });
 
-    // TODO: type after stashapp-api v1
     const favoriteScenes = [
         ...scenesFromFavoritePerformers,
         ...scenesFromFavoriteStudios,
@@ -149,7 +148,6 @@ export const addScenesToFillSpace = async (
             "green"
         );
 
-        // TODO: remove assertion after stashapp-api v1 aligns these types
         const scored = scoreScenes(uniqueFavoriteScenes, favorites as any);
         const sortedByScore = sortScenesByCustomScore(scored);
 
@@ -168,7 +166,6 @@ export const addScenesToFillSpace = async (
     return [...scenesAlreadyIncluded, ...scenesToAdd];
 };
 
-// TODO: type more strictly after stashapp-api v1
 const getAllStashData = async () => {
     const stash = getStashInstance();
     let clearLoading = await loadingText("Getting female Performers");
@@ -185,7 +182,7 @@ const getAllStashData = async () => {
                     },
                 },
             },
-            performers: { id: true, name: true, gender: true, o_counter: true, scene_count: true, favorite: true, rating100: true, scenes: { id: true, o_counter: true } },
+            performers: { ...PerformerFields, scenes: { id: true, o_counter: true } },
         },
     });
     clearLoading("Done");
@@ -204,7 +201,7 @@ const getAllStashData = async () => {
                     },
                 },
             },
-            performers: { id: true, name: true, gender: true, o_counter: true, scene_count: true, favorite: true, rating100: true, scenes: { id: true, o_counter: true } },
+            performers: { ...PerformerFields, scenes: { id: true, o_counter: true } },
         },
     });
     clearLoading("Done");
@@ -214,7 +211,7 @@ const getAllStashData = async () => {
         await stash.query({
             findStudios: {
                 __args: { filter: { per_page: -1 } },
-                studios: { id: true, name: true, favorite: true, rating100: true, o_counter: true },
+                studios: { ...StudioFields },
             },
         });
     clearLoading("Done");
@@ -223,16 +220,16 @@ const getAllStashData = async () => {
     const { findTags: { tags } = { tags: [] } } = await stash.query({
         findTags: {
             __args: { filter: { per_page: -1 } },
-            tags: { id: true, name: true, favorite: true, rating100: true },
+            tags: { ...TagFields },
         },
     });
     clearLoading("Done");
 
     return {
-        femalePerformers: femalePerformers as unknown as Performer[],
-        malePerformers: malePerformers as unknown as Performer[],
-        studios: studios as unknown as Studio[],
-        tags: tags as unknown as Tag[],
+        femalePerformers: femalePerformers as Performer[],
+        malePerformers: malePerformers as Performer[],
+        studios: studios as Studio[],
+        tags: tags as Tag[],
     };
 };
 
@@ -287,8 +284,7 @@ const scoreScene = (
     // initial score will be the o_counter on the Scene
     const initialScore = scene.o_counter ?? 0;
 
-    // TODO: type after stashapp-api v1
-    const performerScore = (scene.performers as Performer[]).reduce(
+    const performerScore = scene.performers.reduce(
         (acc: number, performer) => {
             if (performer.favorite) {
                 if (performer.gender === "FEMALE") {
@@ -302,10 +298,9 @@ const scoreScene = (
         0
     );
 
-    // TODO: type after stashapp-api v1
-    const studioScore = (scene.studio as Studio | null)?.favorite ? weights.studio : 0;
+    const studioScore = scene.studio?.favorite ? weights.studio : 0;
 
-    const tagScore = (scene.tags as Tag[]).reduce((acc: number, tag) => {
+    const tagScore = scene.tags.reduce((acc: number, tag) => {
         if (tag.favorite) {
             acc += weights.tag;
         }
@@ -379,10 +374,9 @@ export const dedupeScenes = (scenes: Scene[]): Scene[] => {
     }, []);
 };
 
-// TODO: type more strictly after stashapp-api v1
 export const getUniquePerformers = (scenes: Scene[]): Performer[] => {
     return scenes.reduce<Performer[]>((acc, { performers }) => {
-        (performers as unknown as Performer[]).forEach((performer) => {
+        performers.forEach((performer) => {
             const isAlreadyAccumulated = Boolean(
                 acc.find(({ id }) => id === performer.id)
             );


### PR DESCRIPTION
## Summary
- Replace manual field selections with `SceneFields`, `PerformerFields`, `StudioFields`, `TagFields` presets from stashapp-api@1.0.1
- Simplify boundary type casts from `as unknown as X[]` to `as X[]` since presets return full types
- Remove resolved TODO comments about v1 type alignment

## Notes
Preserves `parent_studio` relation selection in organizeLibrary where the scalar-only preset doesn't cover the needed relation field.