### PR TITLE
test: expand unit test coverage

### DIFF
--- a/src/controllers/organize/__tests__/filename.test.ts
+++ b/src/controllers/organize/__tests__/filename.test.ts
@@ -1,0 +1,90 @@
+import type { Scene } from "stashapp-api";
+import { describe, expect, it } from "vitest";
+import { buildFileName, getResolution } from "../filename.js";
+import type { UserOrganizationDetails } from "../types.js";
+
+const makeScene = (overrides: Partial<Scene> = {}): Scene => ({
+    id: "123",
+    title: "Test Title",
+    date: "2024-01-15",
+    studio: { id: "s1", name: "TestStudio" },
+    performers: [
+        { id: "p1", name: "Jane", gender: "FEMALE" },
+        { id: "p2", name: "John", gender: "MALE" },
+    ],
+    tags: [{ id: "t1", name: "TagA" }],
+    files: [{ path: "/data/test.mp4", basename: "test.mp4", size: "1000", height: 1080, width: 1920 }],
+    ...overrides,
+} as Scene);
+
+const makeDetails = (overrides: Partial<UserOrganizationDetails> = {}): UserOrganizationDetails => ({
+    organizationType: "Studio",
+    sceneFilter: {},
+    stashDataPath: "/data",
+    maleFilter: false,
+    femaleFilter: false,
+    filenameFormatString: "{date} - {title}.{ext}",
+    ...overrides,
+});
+
+describe("getResolution", () => {
+    it("returns 1080p for 1080 height", () => {
+        expect(getResolution({ height: 1080 })).toBe("1080p");
+    });
+
+    it("returns 4K for 2160 height", () => {
+        expect(getResolution({ height: 2160 })).toBe("4K");
+    });
+
+    it("returns 720p for 720 height", () => {
+        expect(getResolution({ height: 720 })).toBe("720p");
+    });
+
+    it("returns unknown for 0 height", () => {
+        expect(getResolution({ height: 0 })).toBe("unknown");
+    });
+
+    it("returns unknown for missing height", () => {
+        expect(getResolution({})).toBe("unknown");
+    });
+
+    it("returns exact pixels for non-standard heights", () => {
+        expect(getResolution({ height: 144 })).toBe("144p");
+    });
+});
+
+describe("buildFileName", () => {
+    it("builds filename from template", () => {
+        const scene = makeScene();
+        const details = makeDetails({ filenameFormatString: "{date} - {title}.{ext}" });
+        const result = buildFileName(scene, details);
+        expect(result).toBe("2024-01-15 - Test Title.mp4");
+    });
+
+    it("includes performers when template has them", () => {
+        const scene = makeScene();
+        const details = makeDetails({
+            filenameFormatString: "{performers_female} - {title}.{ext}",
+        });
+        const result = buildFileName(scene, details);
+        expect(result).toBe("Jane - Test Title.mp4");
+    });
+
+    it("includes studio in filename", () => {
+        const scene = makeScene();
+        const details = makeDetails({
+            filenameFormatString: "{studio} - {title}.{ext}",
+        });
+        const result = buildFileName(scene, details);
+        expect(result).toBe("TestStudio - Test Title.mp4");
+    });
+
+    it("includes resolution in filename", () => {
+        const scene = makeScene();
+        const details = makeDetails({
+            filenameFormatString: "{title} [{resolution}].{ext}",
+        });
+        const result = buildFileName(scene, details);
+        expect(result).toBe("Test Title [1080p].mp4");
+    });
+});

--- a/src/controllers/organize/__tests__/folders.test.ts
+++ b/src/controllers/organize/__tests__/folders.test.ts
@@ -1,0 +1,44 @@
+import type { Scene } from "stashapp-api";
+import { describe, expect, it } from "vitest";
+import { filterScenesByPerformerSelections } from "../folders.js";
+
+const makeScene = (performers: Array<{ gender: string }> = []): Scene => ({
+    id: "1",
+    performers: performers.map((p, i) => ({
+        id: `p${i}`,
+        name: `Performer ${i}`,
+        ...p,
+    })),
+} as Scene);
+
+describe("filterScenesByPerformerSelections", () => {
+    const scenes = [
+        makeScene([{ gender: "MALE" }, { gender: "FEMALE" }]),
+        makeScene([{ gender: "FEMALE" }]),
+        makeScene([{ gender: "MALE" }]),
+    ];
+
+    it("returns all scenes when no filter", () => {
+        expect(filterScenesByPerformerSelections(scenes, false, false)).toHaveLength(3);
+    });
+
+    it("filters to male-only scenes", () => {
+        const result = filterScenesByPerformerSelections(scenes, true, false);
+        expect(result).toHaveLength(2); // first and third have males
+    });
+
+    it("filters to female-only scenes", () => {
+        const result = filterScenesByPerformerSelections(scenes, false, true);
+        expect(result).toHaveLength(2); // first and second have females
+    });
+
+    it("filters to scenes with both male and female", () => {
+        const result = filterScenesByPerformerSelections(scenes, true, true);
+        expect(result).toHaveLength(1); // only first has both
+    });
+
+    it("returns empty for no matches", () => {
+        const femaleOnly = [makeScene([{ gender: "FEMALE" }])];
+        expect(filterScenesByPerformerSelections(femaleOnly, true, false)).toHaveLength(0);
+    });
+});

--- a/src/utils/__tests__/filesystem.test.ts
+++ b/src/utils/__tests__/filesystem.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeFilename } from "../filesystem.js";
+
+describe("sanitizeFilename", () => {
+    it("replaces Windows-invalid characters", () => {
+        expect(sanitizeFilename('file<>:"/\\|?*.mp4')).toBe("file_________.mp4");
+    });
+
+    it("leaves valid filenames unchanged", () => {
+        expect(sanitizeFilename("normal-file_name.mp4")).toBe("normal-file_name.mp4");
+    });
+
+    it("handles empty string", () => {
+        expect(sanitizeFilename("")).toBe("");
+    });
+
+    it("replaces forward slashes", () => {
+        expect(sanitizeFilename("path/to/file.mp4")).toBe("path_to_file.mp4");
+    });
+});

--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+    calculatePercent,
+    convertMbToBytes,
+    formatBytes,
+    formatHeight,
+    formatPercent,
+    formatWeight,
+} from "../format.js";
+
+describe("calculatePercent", () => {
+    it("calculates percentage from two numbers", () => {
+        expect(calculatePercent(50, 200)).toBe(25);
+    });
+
+    it("handles string inputs", () => {
+        expect(calculatePercent("25", "100")).toBe(25);
+    });
+});
+
+describe("convertMbToBytes", () => {
+    it("converts megabytes to bytes", () => {
+        expect(convertMbToBytes(1)).toBe(1048576);
+        expect(convertMbToBytes(0)).toBe(0);
+    });
+});
+
+describe("formatBytes", () => {
+    it("formats 0 bytes", () => {
+        expect(formatBytes(0)).toBe("0 Bytes");
+    });
+
+    it("formats bytes to KB", () => {
+        expect(formatBytes(1024)).toBe("1 KB");
+    });
+
+    it("formats bytes to MB", () => {
+        expect(formatBytes(1048576)).toBe("1 MB");
+    });
+
+    it("formats bytes to GB", () => {
+        expect(formatBytes(1073741824)).toBe("1 GB");
+    });
+
+    it("respects decimals parameter", () => {
+        expect(formatBytes(1500, 1)).toBe("1.5 KB");
+    });
+});
+
+describe("formatHeight", () => {
+    it("converts cm to feet and inches", () => {
+        expect(formatHeight(170)).toBe(`5'6"`);
+    });
+
+    it("handles short heights", () => {
+        expect(formatHeight(152)).toBe(`4'11"`);
+    });
+});
+
+describe("formatPercent", () => {
+    it("formats number as percentage with ceiling", () => {
+        expect(formatPercent(33.3)).toBe("34%");
+        expect(formatPercent(100)).toBe("100%");
+    });
+});
+
+describe("formatWeight", () => {
+    it("formats weight in pounds", () => {
+        expect(formatWeight(130)).toBe("130lbs");
+    });
+});

--- a/src/utils/__tests__/scenes.test.ts
+++ b/src/utils/__tests__/scenes.test.ts
@@ -1,0 +1,75 @@
+import type { Performer, Scene } from "stashapp-api";
+import { describe, expect, it } from "vitest";
+import { dedupeScenes, getTotalSize, getUniquePerformers } from "../scenes.js";
+
+const makeScene = (overrides: Partial<Scene> = {}): Scene => ({
+    id: "1",
+    title: "Test Scene",
+    rating100: 50,
+    o_counter: 1,
+    date: "2024-01-01",
+    details: "",
+    studio: { id: "s1", name: "Studio A" },
+    performers: [],
+    tags: [],
+    files: [{ path: "/data/test.mp4", basename: "test.mp4", size: "1000" }],
+    paths: { screenshot: "" },
+    ...overrides,
+} as Scene);
+
+describe("dedupeScenes", () => {
+    it("removes duplicate scenes by id", () => {
+        const scenes = [
+            makeScene({ id: "1" }),
+            makeScene({ id: "2" }),
+            makeScene({ id: "1" }),
+        ];
+        const result = dedupeScenes(scenes);
+        expect(result).toHaveLength(2);
+        expect(result.map((s) => s.id)).toEqual(["1", "2"]);
+    });
+
+    it("returns empty array for empty input", () => {
+        expect(dedupeScenes([])).toEqual([]);
+    });
+
+    it("returns same array when no duplicates", () => {
+        const scenes = [makeScene({ id: "1" }), makeScene({ id: "2" })];
+        expect(dedupeScenes(scenes)).toHaveLength(2);
+    });
+});
+
+describe("getTotalSize", () => {
+    it("sums file sizes across scenes", () => {
+        const scenes = [
+            makeScene({ files: [{ path: "/a.mp4", basename: "a.mp4", size: "500" }] } as Partial<Scene>),
+            makeScene({ files: [{ path: "/b.mp4", basename: "b.mp4", size: "300" }] } as Partial<Scene>),
+        ];
+        expect(getTotalSize(scenes)).toBe(800);
+    });
+
+    it("returns 0 for empty array", () => {
+        expect(getTotalSize([])).toBe(0);
+    });
+});
+
+describe("getUniquePerformers", () => {
+    it("extracts unique performers across scenes", () => {
+        const performer1 = { id: "p1", name: "Alice" } as Performer;
+        const performer2 = { id: "p2", name: "Bob" } as Performer;
+
+        const scenes = [
+            makeScene({ performers: [performer1, performer2] as Performer[] }),
+            makeScene({ performers: [performer1] as Performer[] }),
+        ];
+
+        const result = getUniquePerformers(scenes);
+        expect(result).toHaveLength(2);
+        expect(result.map((p) => p.name)).toEqual(["Alice", "Bob"]);
+    });
+
+    it("returns empty array for scenes with no performers", () => {
+        const scenes = [makeScene({ performers: [] })];
+        expect(getUniquePerformers(scenes)).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
- Add 38 new unit tests across 5 new test files (17 → 55 total)
- `scenes.test.ts` — dedupeScenes, getTotalSize, getUniquePerformers
- `format.test.ts` — calculatePercent, convertMbToBytes, formatBytes, formatHeight, formatPercent, formatWeight
- `filesystem.test.ts` — sanitizeFilename
- `organize/filename.test.ts` — buildFileName, getResolution
- `organize/folders.test.ts` — filterScenesByPerformerSelections